### PR TITLE
Deploy deps upgrades

### DIFF
--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -80,7 +80,8 @@ jobs:
           retention-days: 1
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: "!(failure() || cancelled())"
     needs:
       - lint
       - test

--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -81,7 +81,11 @@ jobs:
 
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [lint, test, test-and-sonar, build]
+    needs:
+      - lint
+      - test
+      - test-and-sonar
+      - build
     name: Deploy
     runs-on: ubuntu-latest
 

--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -80,8 +80,8 @@ jobs:
           retention-days: 1
 
   deploy:
-    #if: ${{ github.ref == 'refs/heads/main' }}
-    if: "!(failure() || cancelled())"
+    # make it work with skipped jobs: https://github.com/github/docs/issues/4822#issuecomment-826617890
+    if: ${{ (github.ref == 'refs/heads/main') && !failure() && !cancelled() }}
     needs:
       - lint
       - test

--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -82,11 +82,7 @@ jobs:
   deploy:
     # make it work with skipped jobs: https://github.com/github/docs/issues/4822#issuecomment-826617890
     if: ${{ (github.ref == 'refs/heads/main') && !failure() && !cancelled() }}
-    needs:
-      - lint
-      - test
-      - test-and-sonar
-      - build
+    needs: [lint, test, test-and-sonar, build]
     name: Deploy
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We want to deploy to GitHub pages even when some of the previous jobs were skipped.

Because we run either tests with SonarCloud analysis or just the tests (@dependabot can not access `$SONAR_TOKEN` secret).